### PR TITLE
Make the use of mlflow optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ Testing notebook.ipynb
 /*.png
 /*.zip
 /*.tar.*
+
+# Mlflow
+mlruns/

--- a/a100env.yml
+++ b/a100env.yml
@@ -12,5 +12,8 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - mlflow
     - -r requirements-dev.txt
     - -e .
+variables:
+  MLFLOW_TRACKING_URI: http://127.0.0.1:5000

--- a/hacenv.yml
+++ b/hacenv.yml
@@ -9,5 +9,8 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - mlflow
     - -r requirements-dev.txt
     - -e .
+variables:
+  MLFLOW_TRACKING_URI: http://127.0.0.1:5000

--- a/hacenv2.yml
+++ b/hacenv2.yml
@@ -9,5 +9,8 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - mlflow
     - -r requirements-dev.txt
     - -e .
+variables:
+  MLFLOW_TRACKING_URI: http://127.0.0.1:5000

--- a/hacenv3.yml
+++ b/hacenv3.yml
@@ -9,5 +9,8 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - mlflow
     - -r requirements-dev.txt
     - -e .
+variables:
+  MLFLOW_TRACKING_URI: http://127.0.0.1:5000

--- a/run_batch.sh
+++ b/run_batch.sh
@@ -23,12 +23,10 @@ COMMON_ARGS="""
 
 mkdir -p $LOG_DIR
 
-# Install MLFlow
-pip install mlflow
-# Start MLFlow server in the background
-mlflow server &
-# Wait for the serer to start (5 secs)
-sleep 5
+if [[ -x $(command -v mlflow) ]]; then
+    mlflow server &
+    sleep 5
+fi
 
 while read model; do
     # echo $model

--- a/train.py
+++ b/train.py
@@ -67,6 +67,14 @@ except ImportError as e:
 
 has_compile = hasattr(torch, 'compile')
 
+try:
+    import mlflow
+    if not os.environ.get("MLFLOW_TRACKING_URI", None):
+        mlflow.set_tracking_uri("http://127.0.0.1:5000")
+    has_mlflow = True
+except ImportError:
+    has_mlflow = False
+
 
 _logger = logging.getLogger('train')
 
@@ -766,14 +774,14 @@ def main():
         _logger.info(
             f'Scheduled epochs: {num_epochs}. LR stepped per {"epoch" if lr_scheduler.t_in_epochs else "update"}.')
 
-    # MLFlow init
-    import mlflow
-    mlflow.set_tracking_uri("http://127.0.0.1:5000")
-    experiment_id = mlflow.create_experiment('{}'.format(args.model))
-    experiment = mlflow.get_experiment(experiment_id)
+    # setup mlflow tracking
+    if has_mlflow:
+        experiment_id = mlflow.create_experiment('{}'.format(args.model))
+        experiment = mlflow.get_experiment(experiment_id)
 
     try:
-        mlflow.start_run(run_name=args.model, experiment_id=experiment.experiment_id)
+        if has_mlflow:
+            mlflow.start_run(run_name=args.model, experiment_id=experiment.experiment_id)
         for epoch in range(start_epoch, num_epochs):
             if hasattr(dataset_train, 'set_epoch'):
                 dataset_train.set_epoch(epoch)
@@ -794,7 +802,7 @@ def main():
                 loss_scaler=loss_scaler,
                 model_ema=model_ema,
                 mixup_fn=mixup_fn,
-                mlflow=mlflow,
+                has_mlflow=has_mlflow,
             )
 
             if args.distributed and args.dist_bn in ('broadcast', 'reduce'):
@@ -808,7 +816,7 @@ def main():
                 validate_loss_fn,
                 args,
                 amp_autocast=amp_autocast,
-                mlflow=mlflow,
+                has_mlflow=has_mlflow,
             )
 
             if model_ema is not None and not args.model_ema_force_cpu:
@@ -846,7 +854,8 @@ def main():
                 # step LR for next epoch
                 lr_scheduler.step(epoch + 1, eval_metrics[eval_metric])
 
-        mlflow.end_run()
+        if has_mlflow:
+            mlflow.end_run()
     except KeyboardInterrupt:
         pass
 
@@ -869,7 +878,7 @@ def train_one_epoch(
         loss_scaler=None,
         model_ema=None,
         mixup_fn=None,
-        mlflow=None,
+        has_mlflow=False,
 ):
     if args.mixup_off_epoch and epoch >= args.mixup_off_epoch:
         if args.prefetcher and loader.mixup_enabled:
@@ -989,7 +998,7 @@ def train_one_epoch(
                     f'Data: {data_time_m.val:.3f} ({data_time_m.avg:.3f})'
                 )
 
-                if mlflow != None:
+                if has_mlflow:
                     mlflow.log_metric('loss', losses_m.val)
                     mlflow.log_metric('throughput', update_sample_count / update_time_m.val)
 
@@ -1029,7 +1038,7 @@ def validate(
         device=torch.device('cuda'),
         amp_autocast=suppress,
         log_suffix='',
-        mlflow=None,
+        has_mlflow=False,
 ):
     batch_time_m = utils.AverageMeter()
     losses_m = utils.AverageMeter()
@@ -1088,7 +1097,7 @@ def validate(
                     f'Acc@1: {top1_m.val:>7.3f} ({top1_m.avg:>7.3f})  '
                     f'Acc@5: {top5_m.val:>7.3f} ({top5_m.avg:>7.3f})'
                 )
-                if mlflow != None:
+                if has_mlflow:
                     mlflow.log_metric('val_loss', losses_m.val)
                     mlflow.log_metric('acc_top1', top1_m.val)
                     mlflow.log_metric('acc_top5', top5_m.val)


### PR DESCRIPTION
This PR makes run scripts function independently from `mlflow`. In case it is available, then the tracking features offered by `mlflow` is used, otherwise the scripts run normally.

This mimics the pattern used by `timm` to handle optional dependencies such as `apex`, `torch.compile`, etc etc