### PR TITLE
Run multiple models in parallel with multiple SDAs 

### DIFF
--- a/moreh-parallel-run.sh
+++ b/moreh-parallel-run.sh
@@ -5,7 +5,7 @@
 NUM_SDA=5
 
 # Require GNU parallel
-[[ -x $(command -v parallel) ]] \
+[[ ! -x $(command -v parallel) ]] \
     && echo "Require GNU parallel. To install: sudo apt install parallel" \
     && exit 1
 

--- a/moreh-parallel-run.sh
+++ b/moreh-parallel-run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Assume 5 SDAs are all available, take a list of models, evenly distribute
+# them to 5 SDAs using `run_batch.sh`
+NUM_SDA=5
+
+# Require GNU parallel
+[[ -x $(command -v parallel) ]] \
+    && echo "Require GNU parallel. To install: sudo apt install parallel" \
+    && exit 1
+
+input_file=$1
+[[ ! -f $input_file ]] && echo "Cannot find input file" && exit 1
+
+tmp_dir=$(mktemp --directory)
+
+num_models=$(wc -l $input_file | cut -d" " -f1)
+
+# TODO: what happens if num_models < NUM_SDA? how to handle that case?
+num_models_per_sda=$(((num_models + NUM_SDA - 1) / NUM_SDA))
+
+split --lines=$num_models_per_sda $input_file ${tmp_dir}/timm.
+
+parallel -j $NUM_SDA --link \
+    env MOREH_VISIBLE_DEVICE={2} ./run_batch.sh {1} \
+    ::: ${tmp_dir}/timm.* \
+    ::: 0 1 2 3 4
+
+rm -rf $tmp_dir
+
+wait $(jobs -n)
+[[ -z $(pgrep mlflow) ]] && pkill -f mlflow

--- a/moreh-parallel-run.sh
+++ b/moreh-parallel-run.sh
@@ -2,7 +2,7 @@
 
 # Assume 5 SDAs are all available, take a list of models, evenly distribute
 # them to 5 SDAs using `run_batch.sh`
-NUM_SDA=5
+NUM_SDA_AVAILABLE=5
 
 # Require GNU parallel
 [[ ! -x $(command -v parallel) ]] \
@@ -15,17 +15,15 @@ input_file=$1
 tmp_dir=$(mktemp --directory)
 
 num_models=$(wc -l $input_file | cut -d" " -f1)
-[[ $num_models -lt $NUM_SDA ]] \
-    && echo Too few models: ${num_models} on ${NUM_SDA} && exit 1
-
-num_models_per_sda=$(((num_models + NUM_SDA - 1) / NUM_SDA))
-
+num_models_per_sda=$(((num_models + NUM_SDA_AVAILABLE - 1) / NUM_SDA_AVAILABLE))
 split --lines=$num_models_per_sda $input_file ${tmp_dir}/timm.
+num_sda_in_use=$(ls ${tmp_dir}/timm.* | wc -l)
+sda_in_use=$(seq -s " " 0 $((num_sda_in_use - 1)))
 
-parallel -j $NUM_SDA --link \
+parallel -j $num_sda_in_use --link \
     env MOREH_VISIBLE_DEVICE={2} ./run_batch.sh {1} \
     ::: ${tmp_dir}/timm.* \
-    ::: 0 1 2 3 4
+    ::: ${sda_in_use}
 
 rm -rf $tmp_dir
 

--- a/moreh-parallel-run.sh
+++ b/moreh-parallel-run.sh
@@ -30,4 +30,4 @@ parallel -j $NUM_SDA --link \
 rm -rf $tmp_dir
 
 wait $(jobs -n)
-[[ -z $(pgrep mlflow) ]] && pkill -f mlflow
+[[ ! -z $(pgrep mlflow) ]] && pkill -f mlflow

--- a/moreh-parallel-run.sh
+++ b/moreh-parallel-run.sh
@@ -15,8 +15,9 @@ input_file=$1
 tmp_dir=$(mktemp --directory)
 
 num_models=$(wc -l $input_file | cut -d" " -f1)
+[[ $num_models -lt $NUM_SDA ]] \
+    && echo Too few models: ${num_models} on ${NUM_SDA} && exit 1
 
-# TODO: what happens if num_models < NUM_SDA? how to handle that case?
 num_models_per_sda=$(((num_models + NUM_SDA - 1) / NUM_SDA))
 
 split --lines=$num_models_per_sda $input_file ${tmp_dir}/timm.

--- a/run_batch.sh
+++ b/run_batch.sh
@@ -23,18 +23,14 @@ COMMON_ARGS="""
 
 mkdir -p $LOG_DIR
 
-if [[ -x $(command -v mlflow) ]]; then
+if [[ -x $(command -v mlflow) ]] && [[ -z $(pgrep mlflow) ]]; then
     mlflow server &
     sleep 5
 fi
 
 while read model; do
-    # echo $model
     /usr/bin/env python3 train.py \
         --model $model \
         $COMMON_ARGS \
         2>&1 | tee ${LOG_DIR}/${model}.log
 done < $input_file
-
-# Stop the MLFlow server at the end
-pkill -f mlflow


### PR DESCRIPTION
`moreh-parallel-run.sh`: take a list of `timm` models, evenly distribute them to run on multiple SDAs, leveraging the existing `run_batch.sh`