### PR TITLE
Loctx/upload log s3

### DIFF
--- a/a100env.yml
+++ b/a100env.yml
@@ -12,6 +12,7 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - boto3
     - mlflow
     - -r requirements-dev.txt
     - -e .

--- a/a100env2.yml
+++ b/a100env2.yml
@@ -12,6 +12,7 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - boto3
     - mlflow
     - -r requirements-dev.txt
     - -e .

--- a/a100env2.yml
+++ b/a100env2.yml
@@ -1,0 +1,17 @@
+name: timm2
+channels:
+  - pytorch
+  - nvidia
+dependencies:
+  - python=3.8
+  - pytorch=1.13.1
+  - torchvision
+  - pytorch-cuda=11.6
+  - pip
+  - pip:
+    - pyyaml
+    - huggingface_hub
+    - safetensors>=0.2
+    - mlflow
+    - -r requirements-dev.txt
+    - -e .

--- a/hacenv.yml
+++ b/hacenv.yml
@@ -9,6 +9,7 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - boto3
     - mlflow
     - -r requirements-dev.txt
     - -e .

--- a/hacenv2.yml
+++ b/hacenv2.yml
@@ -9,6 +9,7 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - boto3
     - mlflow
     - -r requirements-dev.txt
     - -e .

--- a/hacenv3.yml
+++ b/hacenv3.yml
@@ -9,6 +9,7 @@ dependencies:
     - pyyaml
     - huggingface_hub
     - safetensors>=0.2
+    - boto3
     - mlflow
     - -r requirements-dev.txt
     - -e .

--- a/moreh-upload-log-S3.py
+++ b/moreh-upload-log-S3.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import boto3
+from argparse import ArgumentParser
+
+# awscli credential
+ACCESS_KEY = os.environ.get("S3_ACCESS_KEY", None)
+SECRET_KEY = os.environ.get("S3_SECRET_KEY", None)
+
+
+def parse_args():
+    parser = ArgumentParser(description="Upload a log file to moreh-vietnam AWS S3")
+    parser.add_argument("filename")
+    parser.add_argument("--folder", default="")
+
+    args = parser.parse_args()
+    return args
+
+
+def upload(path, directory):
+    """Upload a file to moreh-vietnam bucket.
+
+    Args:
+        path : file path. It can be a relative path or an absolute path.
+    """
+    s3 = boto3.resource(
+        "s3", aws_access_key_id=ACCESS_KEY, aws_secret_access_key=SECRET_KEY
+    )
+
+    # .txt suffix make us to open a uploaded file to be easily read.
+    suffix = ".txt"
+    basename = os.path.basename(path)
+    if not directory:
+        s3_object_key = f"{basename}{suffix}"
+    else:
+        s3_object_key = f"{directory}/{basename}{suffix}"
+    bucket_name = 'moreh-vietnam'
+
+    s3.Bucket(bucket_name).upload_file(
+        path,
+        s3_object_key,
+        ExtraArgs={"ContentType": "text/plain", "ACL": "public-read"},
+    )
+    s3_url = f"https://{bucket_name}.s3.ap-northeast-2.amazonaws.com/{s3_object_key}"
+    print(f"{basename} -> {s3_url}")
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    if not ACCESS_KEY or not SECRET_KEY:
+        print("Keys for accessing AmazonAWS S3 not found!", file=sys.stderr)
+        sys.exit(1)
+
+    upload(args.filename, args.folder)

--- a/run_batch.sh
+++ b/run_batch.sh
@@ -33,4 +33,8 @@ while read model; do
         --model $model \
         $COMMON_ARGS \
         2>&1 | tee ${LOG_DIR}/${model}.log
+
+    if [[ ! -z $S3_ACCESS_KEY ]] && [[ ! -z $S3_SECRET_KEY ]]; then
+        ./moreh-upload-log-S3.py ${LOG_DIR}/${model}.log --folder timm/${HOSTNAME}
+    fi
 done < $input_file


### PR DESCRIPTION
* Add script to uploading log to S3
  * Filename convention: `...amazonaws.com/timm/${HOSTNAME}/${model}.log.txt` 
* `run_batch.sh` now try to upload log to S3 whenever both access key and secret key are found in shell environment
  * Note: it does not matter how these two keys are found in the env. You can either:
    * Add them in `~/.bashrc` / `~/.profile` / `~/.bash_profile`
    * Source a shell script that export them before running `run_batch.sh`
    * Pass them directly to the shell that run `run_batch.sh`. For example, run: `env S3_ACCESS_KEY="bla" S3_SECRET_KEY="bla" ./run_batch.sh`  