### PR TITLE
log val acc by each epoch, instead of each log interval

### DIFF
--- a/train.py
+++ b/train.py
@@ -1131,8 +1131,10 @@ def validate(
                 )
                 if has_mlflow:
                     mlflow.log_metric('val_loss', losses_m.val)
-                    mlflow.log_metric('val_acc_top1', top1_m.val)
-                    mlflow.log_metric('val_acc_top5', top5_m.val)
+
+        if has_mlflow:
+            mlflow.log_metric('val_acc_top1', top1_m.avg)
+            mlflow.log_metric('val_acc_top5', top5_m.avg)
 
     # NOTE: this throughput calculation does not take distributed training into
     # account


### PR DESCRIPTION
Log validation metrics once, at the end of each epoch, instead of logging at every `log_interval`. 

Since accuracy logged at each `log_interval` is associated with each batch of data, the metrics looks fluctuated (see attached image), since there are batches getting good predictions and also batches getting bad predictions. What really matters is the accuracy over the entire validation set, which should be logged instead.

![Screenshot from 2023-12-06 09-59-54](https://github.com/moreh-dev/pytorch-image-models/assets/112361917/715f34ae-494a-459f-80ec-a9c4e70db772)
