### PR TITLE
Update setuptools to 69.5.1

### DIFF
--- a/requirements.moreh.txt
+++ b/requirements.moreh.txt
@@ -2,4 +2,4 @@
 pyyaml
 huggingface_hub
 safetensors>=0.2
-setuptools==65.5.0
+setuptools==69.5.1

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+CUDA_VISIBLE_DEVICES=0 python3 train.py \
+    --model resnet50 \
+    --data-dir ../datasets/mnist \
+    --epochs 10 \
+    -b 256 -vb 256 \
+    --seed 42 -j 8


### PR DESCRIPTION
## Background
Our latest `moreh_driver` (version `24.8.3020`) on Nexus requires `setuptools` version `69.5.1`. However, our benchmarks are currently using `setuptools` version `65.5.0`, as specified in our `requirements.moreh.txt` file, which is causing compatibility issues.

## Contents
- Update `setuptools` to `69.5.1`.